### PR TITLE
Adds a short description and homepage to gemspec

### DIFF
--- a/marcy.gemspec
+++ b/marcy.gemspec
@@ -9,9 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Harry Mills"]
   spec.email         = ["harry@freeagent.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{This is a Ruby client gem for accessing HMRC's new APIs.}
+  spec.homepage      = "https://github.com/haegin/marcy"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or


### PR DESCRIPTION
This allows the Gem to be build without complaints. This also removes the description, leaving space for it to be later filled in with more details.
